### PR TITLE
DriveDistance PID Tuning + OSF Competition Changes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -112,7 +112,7 @@ public final class Constants {
     public static final double CLIMBER_MOTOR_VOLTAGE_COMP = 11;
     public static final double CLIMBER_MOTOR_INITIALIZE_SPEED = -0.60;
     public static final double CLIMBER_MOTOR_DOWN_LIMIT = 0.0;
-    public static final double CLIMBER_MOTOR_UP_LIMIT = 381.0;
+    public static final double CLIMBER_MOTOR_UP_LIMIT = 430.0;
     public static final int CLIMBER_LIMIT_PORT = 0;
     public static final double CLIMBER_MOTOR_UP_SPEED = 1.00;
     public static final double CLIMBER_MOTOR_DOWN_SPEED = -0.50;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -98,11 +98,11 @@ public final class Constants {
     public static final double ALGAE_ARM_REACH_SPEED = -0.2;
     public static final double ALGAE_ARM_HOME_POSITION = 0.135;
     public static final double ALGAE_ARM_INTAKE_POSITION = 0.001;
-    public static final double INTAKE_MOTOR_SPEED = 0.75;
+    public static final double INTAKE_MOTOR_SPEED = 1.00;
     public static final double INTAKE_HOLD_MOTOR_SPEED = 0.10;
     public static final double PIVOT_HOLD_MOTOR_SPEED = 0.05;
     public static final int SENSOR_LIMIT = 750;
-    public static final double ALGAE_ARM_RETURN_SPEED = 0.4;
+    public static final double ALGAE_ARM_RETURN_SPEED = 0.6;
     public static final double SHOOT_MOTOR_SPEED = -0.9;
   }
 
@@ -127,7 +127,7 @@ public final class Constants {
     public static final double k_rightAngle1 = 45;
     public static final double k_rightDist2 = -88;
     public static final double k_middleDist1 = -88;
-    public static final double k_rollerForwardSpeed = 0.30;
+    public static final double k_rollerForwardSpeed = 0.20;
     public static final double k_rollerReverseSpeed = 0.0;
     public static final double k_sideDist1 = -144.0;
   }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -43,12 +43,12 @@ public final class Constants {
     public static final int kRightFrontCanId = 4;
     public static final int kLeftRearCanId = 1;
     public static final int kRightRearCanId = 3;
-    public static final double kDriveP = 1;
+    public static final double kDriveP = 0.35;
     public static final double kDriveI = 0;
-    public static final double kDriveD = 0.12;
+    public static final double kDriveD = 0.02;
     public static final double kTurnP = 0.06;
     public static final double kTurnI = 0.0;
-    public static final double kTurnD  = 0.004;
+    public static final double kTurnD  = 0.0;
     public static final double kDriveToleranceInches = 1.0;
     public static final double kDriveToleranceInchesPerS = 0;
     public static final double kTurnToleranceDeg = 1.5;
@@ -120,14 +120,14 @@ public final class Constants {
   }
 
   public static final class AutosConstants {
-    public static final double k_leftDist1 = 58;
+    public static final double k_leftDist1 = -58;
     public static final double k_leftAngle1 = -45;
-    public static final double k_leftDist2 = 89;
-    public static final double k_rightDist1 = 56;
+    public static final double k_leftDist2 = -89;
+    public static final double k_rightDist1 = -56;
     public static final double k_rightAngle1 = 45;
-    public static final double k_rightDist2 = 88;
-    public static final double k_middleDist1 = 88;
-    public static final double k_rollerForwardSpeed = 0.0;
+    public static final double k_rightDist2 = -88;
+    public static final double k_middleDist1 = -88;
+    public static final double k_rollerForwardSpeed = 0.30;
     public static final double k_rollerReverseSpeed = 0.0;
   }
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -129,6 +129,7 @@ public final class Constants {
     public static final double k_middleDist1 = -88;
     public static final double k_rollerForwardSpeed = 0.30;
     public static final double k_rollerReverseSpeed = 0.0;
+    public static final double k_sideDist1 = -144.0;
   }
 
   public static final class RobotConstants {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -61,7 +61,7 @@ public class RobotContainer {
       m_algaePicker = new AlgaePickerSubsystem();
       m_climber = new Climber();
       // Creates UsbCamera
-      //CameraServer.startAutomaticCapture();
+      CameraServer.startAutomaticCapture();
     }
     // Configure the trigger bindings
     configureBindings();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,29 +4,29 @@
 
 package frc.robot;
 
+import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
-import edu.wpi.first.wpilibj2.command.Subsystem;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.robot.Constants.ControllerConstants;
-import frc.robot.Constants.OperatorConstants;
-import frc.robot.Constants.RollerConstants;
-import frc.robot.Constants.RobotConstants;
-import frc.robot.Constants.AlgaeConstants;
 import frc.robot.Constants.ButtonConstants;
 import frc.robot.Constants.ChassisConstants;
+import frc.robot.Constants.ControllerConstants;
+import frc.robot.Constants.OperatorConstants;
+import frc.robot.Constants.RobotConstants;
+import frc.robot.Constants.RollerConstants;
 import frc.robot.commands.Autos;
-import frc.robot.commands.ReachAndGrab;
 import frc.robot.commands.DriveDistanceCommand;
+import frc.robot.commands.ReachAndGrab;
 import frc.robot.commands.TurnToAngle;
+import frc.robot.subsystems.AlgaePickerSubsystem;
 import frc.robot.subsystems.ChassieSubSystem;
 import frc.robot.subsystems.Climber;
 import frc.robot.subsystems.CoralRoller;
-import frc.robot.subsystems.AlgaePickerSubsystem;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -60,6 +60,8 @@ public class RobotContainer {
       m_coralRoller = new CoralRoller();
       m_algaePicker = new AlgaePickerSubsystem();
       m_climber = new Climber();
+      // Creates UsbCamera
+      CameraServer.startAutomaticCapture();
     }
     // Configure the trigger bindings
     configureBindings();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -61,7 +61,7 @@ public class RobotContainer {
       m_algaePicker = new AlgaePickerSubsystem();
       m_climber = new Climber();
       // Creates UsbCamera
-      CameraServer.startAutomaticCapture();
+      //CameraServer.startAutomaticCapture();
     }
     // Configure the trigger bindings
     configureBindings();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -66,6 +66,7 @@ public class RobotContainer {
     autochooser.addOption("left", Autos.simpleAutoLeft(m_ChassieSubsystem, m_coralRoller));
     autochooser.addOption("middle", Autos.simpleAutoMiddle(m_ChassieSubsystem, m_coralRoller));
     autochooser.addOption("right", Autos.simpleAutoRight(m_ChassieSubsystem, m_coralRoller));
+    autochooser.addOption("long", Autos.simpleAutoSide(m_ChassieSubsystem, m_coralRoller));
     SmartDashboard.putData("AutoPosition", autochooser);
 
   }

--- a/src/main/java/frc/robot/commands/Autos.java
+++ b/src/main/java/frc/robot/commands/Autos.java
@@ -32,6 +32,7 @@ public final class Autos {
   public static Command simpleAutoMiddle(ChassieSubSystem subsystem, CoralRoller coralSubsystem) {
     if (coralSubsystem != null) {
       return new DriveDistanceCommand(AutosConstants.k_middleDist1, subsystem)
+      .withTimeout(4.0)
         .andThen(coralSubsystem.runRoller(coralSubsystem, () -> AutosConstants.k_rollerForwardSpeed, () -> AutosConstants.k_rollerReverseSpeed));
     }
     else {

--- a/src/main/java/frc/robot/commands/Autos.java
+++ b/src/main/java/frc/robot/commands/Autos.java
@@ -40,6 +40,17 @@ public final class Autos {
     }
   }
 
+  public static Command simpleAutoSide(ChassieSubSystem subsystem, CoralRoller coralSubsystem) {
+    if (coralSubsystem != null) {
+      return new DriveDistanceCommand(AutosConstants.k_sideDist1, subsystem)
+      .withTimeout(4.0)
+        .andThen(coralSubsystem.runRoller(coralSubsystem, () -> AutosConstants.k_rollerForwardSpeed, () -> AutosConstants.k_rollerReverseSpeed));
+    }
+    else {
+      return new DriveDistanceCommand(AutosConstants.k_sideDist1, subsystem);
+    }
+  }
+
   public static Command simpleAutoRight(ChassieSubSystem subsystem, CoralRoller coralSubsystem) {
     if (coralSubsystem != null) {
       return new DriveDistanceCommand(AutosConstants.k_rightDist1, subsystem)
@@ -51,6 +62,16 @@ public final class Autos {
       return new DriveDistanceCommand(AutosConstants.k_rightDist1, subsystem)
         .andThen(new TurnToAngle(AutosConstants.k_rightAngle1, subsystem))
         .andThen(new DriveDistanceCommand(AutosConstants.k_rightDist2, subsystem));
+    }
+  }
+
+  public static Command simpleAuto(ChassieSubSystem subsystem, CoralRoller coralSubsystem) {
+    if (coralSubsystem != null) {
+      return new DriveDistanceCommand(AutosConstants.k_middleDist1, subsystem)
+      .withTimeout(4.0);
+    }
+    else {
+      return new DriveDistanceCommand(AutosConstants.k_middleDist1, subsystem);
     }
   }
 

--- a/src/main/java/frc/robot/commands/ReachAndGrab.java
+++ b/src/main/java/frc/robot/commands/ReachAndGrab.java
@@ -30,7 +30,7 @@ public class ReachAndGrab extends Command {
     public void initialize() {
         picker.runpivotmotor(AlgaeConstants.ALGAE_ARM_REACH_SPEED);
         picker.runintakemotor(AlgaeConstants.INTAKE_MOTOR_SPEED);
-        picker.setBrake(true);
+        picker.setBrake(true, false);
     }
 
     @Override
@@ -39,9 +39,9 @@ public class ReachAndGrab extends Command {
         picker.runintakemotor(AlgaeConstants.INTAKE_MOTOR_SPEED);
         if (picker.arminintakeposition()) {
             picker.runpivotmotor(0);
-            picker.setBrake(false);
+            picker.setBrake(false, false);
         }else{
-            picker.setBrake(true);
+            picker.setBrake(true, false);
             picker.runpivotmotor(AlgaeConstants.ALGAE_ARM_REACH_SPEED);
         }
     }

--- a/src/main/java/frc/robot/subsystems/AlgaePickerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AlgaePickerSubsystem.java
@@ -79,13 +79,28 @@ public class AlgaePickerSubsystem extends SubsystemBase {
     }
 
     public boolean arminintakeposition() {
-        return pivotEncoder.getPosition() < AlgaeConstants.ALGAE_ARM_INTAKE_POSITION
-                || pivotEncoder.getPosition() > AlgaeConstants.ALGAE_ARM_INTAKE_POSITION + 0.5;
+        double pivotposition = pivotEncoder.getPosition();
+        boolean pivotintakepart1 = pivotposition < AlgaeConstants.ALGAE_ARM_INTAKE_POSITION;
+
+        boolean pivotintakepart2 =  pivotposition > AlgaeConstants.ALGAE_ARM_INTAKE_POSITION + 0.5;
+        SmartDashboard.putNumber("pivotposition",pivotposition );
+        SmartDashboard.putNumber("pivotintakelimit2", AlgaeConstants.ALGAE_ARM_INTAKE_POSITION + 0.5);
+        SmartDashboard.putBoolean("pivotintakepart1", pivotintakepart1);
+        SmartDashboard.putBoolean("pivotintakepart2", pivotintakepart2);
+        SmartDashboard.putBoolean("pivotinintakeposition", pivotintakepart1 || pivotintakepart2);
+
+        return pivotintakepart1 || pivotintakepart2;
     }
 
     public boolean arminhomeposition() {
-        return pivotEncoder.getPosition() > AlgaeConstants.ALGAE_ARM_HOME_POSITION
-                && pivotEncoder.getPosition() < AlgaeConstants.ALGAE_ARM_HOME_POSITION + 0.5;
+        double pivotposition = pivotEncoder.getPosition();
+        boolean pivothomepart1 = pivotposition > AlgaeConstants.ALGAE_ARM_HOME_POSITION;
+        boolean pivothomepart2 = pivotposition < AlgaeConstants.ALGAE_ARM_HOME_POSITION + 0.5;
+        SmartDashboard.putBoolean("pivothomepart1", pivothomepart1);
+        SmartDashboard.putBoolean("pivothomepart2", pivothomepart2);
+        SmartDashboard.putBoolean("pivotinhomeposition",pivothomepart1 && pivothomepart2);        
+        
+        return pivothomepart1 && pivothomepart2;
     }
 
     public double getPivotAngle() {
@@ -154,5 +169,7 @@ public class AlgaePickerSubsystem extends SubsystemBase {
         SmartDashboard.putNumber("armAngle", pivotEncoder.getPosition());
         SmartDashboard.putNumber("armSpeed", pivotMotor.get());
         SmartDashboard.putNumber("intake speed", intakeMotor.get());
+        arminhomeposition();
+        arminintakeposition();
     }
 }

--- a/src/main/java/frc/robot/subsystems/AlgaePickerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AlgaePickerSubsystem.java
@@ -107,7 +107,7 @@ public class AlgaePickerSubsystem extends SubsystemBase {
         return pivotEncoder.getPosition();
     }
 
-    public void setBrake(boolean enabled) {
+    public void setBrake(boolean enabled, boolean sync) {
         SparkMaxConfig config = new SparkMaxConfig();
         if (enabled) {
             config
@@ -118,7 +118,15 @@ public class AlgaePickerSubsystem extends SubsystemBase {
             config
                     .idleMode(IdleMode.kCoast);
         }
-        pivotMotor.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+
+        if (sync)
+        {
+            pivotMotor.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+        }
+        else
+        {
+            pivotMotor.configureAsync(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+        }
     }
 
     public Command reachForAlgae(
@@ -138,6 +146,7 @@ public class AlgaePickerSubsystem extends SubsystemBase {
                 () -> {
                     intakeMotor.set(AlgaeConstants.INTAKE_HOLD_MOTOR_SPEED);
                     pivotMotor.set(AlgaeConstants.PIVOT_HOLD_MOTOR_SPEED);
+                    setBrake(true, false);
                 },
                 algaeSubsystem);
     }
@@ -148,6 +157,7 @@ public class AlgaePickerSubsystem extends SubsystemBase {
                 () -> {
                     pivotMotor.set(AlgaeConstants.ALGAE_ARM_RETURN_SPEED);
                     intakeMotor.set(AlgaeConstants.INTAKE_HOLD_MOTOR_SPEED);
+                    setBrake(true, false);
                 },
                 () -> pivotMotor.set(0),
                 algaeSubsystem)

--- a/src/main/java/frc/robot/subsystems/AlgaePickerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AlgaePickerSubsystem.java
@@ -80,7 +80,7 @@ public class AlgaePickerSubsystem extends SubsystemBase {
 
     public boolean arminintakeposition() {
         return pivotEncoder.getPosition() < AlgaeConstants.ALGAE_ARM_INTAKE_POSITION
-                || pivotEncoder.getPosition() > AlgaeConstants.ALGAE_ARM_HOME_POSITION;
+                || pivotEncoder.getPosition() > AlgaeConstants.ALGAE_ARM_INTAKE_POSITION + 0.5;
     }
 
     public boolean arminhomeposition() {

--- a/src/main/java/frc/robot/subsystems/ChassieSubSystem.java
+++ b/src/main/java/frc/robot/subsystems/ChassieSubSystem.java
@@ -12,6 +12,7 @@ import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkFlexConfig;
 import com.studica.frc.AHRS;
 
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -28,6 +29,10 @@ public class ChassieSubSystem extends SubsystemBase {
 
   public ChassieSubSystem() {
     m_gyro = new AHRS(ChassisConstants.kGyroPort);
+    m_gyro.reset();
+    Timer.delay(0.1);
+
+
     m_leftFront = new SparkFlex(ChassisConstants.kLeftFrontCanId, MotorType.kBrushless);
     m_rightFront = new SparkFlex(ChassisConstants.kRightFrontCanId, MotorType.kBrushless);
     m_leftRear = new SparkFlex(ChassisConstants.kLeftRearCanId, MotorType.kBrushless);

--- a/vendordeps/REVLib-2025.0.2.json
+++ b/vendordeps/REVLib-2025.0.2.json
@@ -1,7 +1,7 @@
 {
-    "fileName": "REVLib-2025.0.0.json",
+    "fileName": "REVLib-2025.0.2.json",
     "name": "REVLib",
-    "version": "2025.0.0",
+    "version": "2025.0.2",
     "frcYear": "2025",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
@@ -12,19 +12,18 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2025.0.0"
+            "version": "2025.0.2"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2025.0.0",
+            "version": "2025.0.2",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
                 "windowsx86-64",
-                "windowsx86",
                 "linuxarm64",
                 "linuxx86-64",
                 "linuxathena",
@@ -37,14 +36,13 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2025.0.0",
+            "version": "2025.0.2",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
                 "windowsx86-64",
-                "windowsx86",
                 "linuxarm64",
                 "linuxx86-64",
                 "linuxathena",
@@ -55,14 +53,13 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2025.0.0",
+            "version": "2025.0.2",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
                 "windowsx86-64",
-                "windowsx86",
                 "linuxarm64",
                 "linuxx86-64",
                 "linuxathena",


### PR DESCRIPTION
-  PID tuning for drivedistance
- Algae intake run faster
- Recalibrated climber limit for backup climber
- Adding power to the algae arm return
- Flipped the signs for autos, and those auto changes have not ben tested
- Added support for camera on shuffleboard
- Added long option for autos, for left and right placement
- Added 4.0 second timeout for middle auto
- Added simpleautoSide for long auto 
- Added simple auto and does not shoot out coral 
- Added more setbrakes to manage the alage picker
- Added more debug data for pivot arm
- Update REVLib to 2025.0.2 to work around a missed status frame crash